### PR TITLE
Add loading and saving to Main Menu

### DIFF
--- a/3380-game/Assets/Scripts/MainMenu.cs
+++ b/3380-game/Assets/Scripts/MainMenu.cs
@@ -39,7 +39,7 @@ public partial class MainMenu : CanvasLayer
 		// Load elements if it is the first load and they are loadable
 		if (_isFirstLoad)
 		{
-			foreach (var child in gameSceneNode.GetChildren())
+			foreach (var child in GetParent().GetChildren())
 			{
 				if (child is Loadable loadable)
 				{

--- a/3380-game/Assets/Scripts/MainMenu.cs
+++ b/3380-game/Assets/Scripts/MainMenu.cs
@@ -1,8 +1,11 @@
 using Godot;
 using System;
+using Game.Assets.Scripts.Loading;
+using Game.Assets.Scripts.Saving;
 
 public partial class MainMenu : CanvasLayer
 {
+	private bool _isFirstLoad = true;
 	// Called when the node enters the scene tree for the first time.
 	///Makes it so the play and exit button both function as intended when esc is pressed or game is 'paused'.
 	public override void _Ready(){
@@ -23,7 +26,6 @@ public partial class MainMenu : CanvasLayer
 		GetTree().Paused = false;
 		
 		var mainChildren = GetParent().GetChildren();
-		
 		foreach(var child in mainChildren){
 			//If statement is so whenever the start button is pressed, it doesn't continously create a new node of Player scene
 			if(child.Name == "Player")
@@ -34,10 +36,31 @@ public partial class MainMenu : CanvasLayer
 		var gameScene = GD.Load<PackedScene>("res://Scenes//Player.tscn");
 		var gameSceneNode = gameScene.Instantiate();
 		GetParent().AddChild(gameSceneNode);
+		// Load elements if it is the first load and they are loadable
+		if (_isFirstLoad)
+		{
+			foreach (var child in gameSceneNode.GetChildren())
+			{
+				if (child is Loadable loadable)
+				{
+					loadable.Load();
+				}
+			}
+
+			_isFirstLoad = false;
+		}
 		
 	}
 	///Functionality for the exit button
 	public void OnExitPressed(){
+		// Save any savables on exit
+		foreach (var child in GetParent().GetChildren())
+		{
+			if (child is Savable savable)
+			{
+				savable.Save();
+			}
+		}
 		GetTree().Quit();
 	}
 }

--- a/3380-game/Assets/Scripts/Player.cs
+++ b/3380-game/Assets/Scripts/Player.cs
@@ -19,7 +19,6 @@ public partial class Player : Area2D, Loadable, Savable
     public override void _Ready() //called on start
     {
         ScreenSize = GetViewportRect().Size;
-        Load();
     }
 
     public override void _Process(double delta) //called in real time
@@ -95,16 +94,6 @@ public partial class Player : Area2D, Loadable, Savable
             }
         } 
         //end of delta
-    }
-
-    // Handle quit requests so that data is saved before the quit occurs
-    public override void _Notification(int what)
-    {
-        if (what == NotificationWMCloseRequest)
-        {
-            Save();
-            GetTree().Quit();
-        }
     }
 
     //end of code


### PR DESCRIPTION
This pull request moves the file loading and saving added in #4 from the Player class to the Main Menu. This code should also theoretically be able to handle any other nodes that need to be saved and loaded, though this will only work if they implement `Loadable` and/or `Savable` and are direct descendants of the parent game scene node, with the latter requirement only existing as of now to reduce code complexity. 