### PR TITLE
Add stat generation

### DIFF
--- a/3380-game/Assets/Scripts/CharCreate.cs
+++ b/3380-game/Assets/Scripts/CharCreate.cs
@@ -69,10 +69,10 @@ class PlayerData
         var random = new Random();
         while (points > 0)
         {
-            var statChoice = statDictionary.ElementAt(random.Next(0, statDictionary.Count));
-            if (statChoice.Value < 21)
+            var statKey = statDictionary.Keys.ElementAt(random.Next(0, statDictionary.Count));
+            if (statDictionary[statKey] < 21)
             {
-                statDictionary[statChoice.Key] = statChoice.Value + 1;
+                statDictionary[statKey]++;
                 points--;
             }
         }

--- a/3380-game/Assets/Scripts/CharCreate.cs
+++ b/3380-game/Assets/Scripts/CharCreate.cs
@@ -134,7 +134,7 @@ class Program
         }
 
         PlayerData player = new PlayerData(name, characterClass, race, eyeColor, hairColor, facialMarkings);
-        player.RandomizeStats();
+        player.RandomizeStats(3, 20);
         player.DisplayCharacter();
     }
 }

--- a/3380-game/Assets/Scripts/CharCreate.cs
+++ b/3380-game/Assets/Scripts/CharCreate.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 class PlayerData
 {
@@ -46,6 +48,40 @@ class PlayerData
         {
             Feature = "Unknown";
         }
+    }
+    
+    /// <summary>
+    /// Randomizes the stats for a character given a minimum amount of points per stat and a number of points to distribute
+    /// </summary>
+    /// <param name="minimumPerStat">The minimum number of points each stat should start with</param>
+    /// <param name="points">The total number of points that should be randomly distributed</param>
+    public void RandomizeStats(int minimumPerStat, int points)
+    {
+        var statDictionary = new Dictionary<string, int>
+        {
+            {"strength", minimumPerStat},
+            {"dexterity", minimumPerStat},
+            {"intelligence", minimumPerStat},
+            {"constitution", minimumPerStat},
+            {"wisdom", minimumPerStat},
+            {"charisma", minimumPerStat},
+        };
+        var random = new Random();
+        while (points > 0)
+        {
+            var statChoice = statDictionary.ElementAt(random.Next(0, statDictionary.Count));
+            if (statChoice.Value < 21)
+            {
+                statDictionary[statChoice.Key] = statChoice.Value + 1;
+                points--;
+            }
+        }
+        Strength = statDictionary["strength"];
+        Dexterity = statDictionary["dexterity"];
+        Intelligence = statDictionary["intelligence"];
+        Constitution = statDictionary["constitution"];
+        Wisdom = statDictionary["wisdom"];
+        Charisma = statDictionary["charisma"];
     }
     
     public void DisplayCharacter()
@@ -98,6 +134,7 @@ class Program
         }
 
         PlayerData player = new PlayerData(name, characterClass, race, eyeColor, hairColor, facialMarkings);
+        player.RandomizeStats();
         player.DisplayCharacter();
     }
 }

--- a/3380-game/Assets/Scripts/CharCreate.cs
+++ b/3380-game/Assets/Scripts/CharCreate.cs
@@ -47,7 +47,7 @@ class PlayerData
             Feature = "Unknown";
         }
     }
-
+    
     public void DisplayCharacter()
     {
         Console.WriteLine("\nCharacter Created!");


### PR DESCRIPTION
This PR adds a method `randomizeStats(minimumPerStat, points)` to the `PlayerData` class that was introduced in #9. This method, given a minimum amount of points each stat should start with and a number of points that should be randomly allocated, modifies the stats stored in the PlayerData class accordingly. The algorithm utilizes these parameters as this provides a baseline for all characters to ensure they aren't _too_ low in one area while still having randomization in where points afterwards go. The implementation of this algorithm, albeit not perfect, is in my opinion close to the best one can get given the limitations of stats being defined as simple `int` properties and the lack of usage of reflection (which could potentially break AOT builds if used).

This PR additionally adds a sample call to this method in the existing driver code and also fixes the file itself to be a C# code file and to be located alongside our other code files (as was discussed in the Discord group chat).