### PR TITLE
Enable stretching in project settings

### DIFF
--- a/3380-game/Assets/Sprites/bodies/3380 player_b1.png.import
+++ b/3380-game/Assets/Sprites/bodies/3380 player_b1.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cr1jnakw4drkq"
-path="res://.godot/imported/3380 player_b1.png-365dcb89a9375b4b3dab2806ded30918.ctex"
+path="res://.godot/imported/3380 player_b1.png-4174d14c4413bc3d150726a1e632e215.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Assets/Sprites/3380 player_b1.png"
-dest_files=["res://.godot/imported/3380 player_b1.png-365dcb89a9375b4b3dab2806ded30918.ctex"]
+source_file="res://Assets/Sprites/bodies/3380 player_b1.png"
+dest_files=["res://.godot/imported/3380 player_b1.png-4174d14c4413bc3d150726a1e632e215.ctex"]
 
 [params]
 

--- a/3380-game/project.godot
+++ b/3380-game/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://Scenes/main_menu.tscn"
 config/features=PackedStringArray("4.3", "C#", "Forward Plus")
 config/icon="res://icon.svg"
 
+[display]
+
+window/stretch/mode="viewport"
+
 [dotnet]
 
 project/assembly_name="3380 Game"


### PR DESCRIPTION
This pull request modifies the stretch mode in Project Settings to be based on the viewport instead of being disabled, fixing the bug task titled "Bug - Resizing leaves gray space" on the kanban board.