### PR TITLE
Link player sprites to character creator

### DIFF
--- a/3380-game/Assets/Scripts/CharCreate.cs
+++ b/3380-game/Assets/Scripts/CharCreate.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class PlayerData
+public class PlayerData
 {
 
 	public string Name { get; set; }

--- a/3380-game/Assets/Scripts/Player.cs
+++ b/3380-game/Assets/Scripts/Player.cs
@@ -12,9 +12,8 @@ public partial class Player : Area2D
 	//public delegate void HitEventHandler();
 	
 	public Vector2 screenSize;
-	
-
-	public string species = "Twilek";
+		
+	public PlayerData PlayerData;
 	public string bodyType = "1";
 	public string pChoice = "1", eChoice = "3", hChoice = "12";
 
@@ -22,7 +21,12 @@ public partial class Player : Area2D
 public override void _Ready() //called on start
 {
 	screenSize = GetViewportRect().Size;
-	 Load();
+	Load();
+	// If our PlayerData hasn't been defined elsewhere, use one with default values
+	if (PlayerData is null)
+	{
+		PlayerData = new PlayerData("Default", "Soldier", "Twilek", "Red", "Black", "Blue");
+	}
 }
 
 public override void _Process(double delta) //called in real time
@@ -54,7 +58,7 @@ if (velocity.Length() > 0){
 	eye.Play();
 	
 	//check to make sure only the ones with patterns have the node active
-	if(species == "Human" || species == "Pureblood"){
+	if(PlayerData.Race == "Human" || PlayerData.Race == "Pureblood"){
 		pattern.Hide();
 
 		if(StringExtensions.ToInt(hChoice) > 10){
@@ -101,7 +105,7 @@ public void AnimationTurn(AnimatedSprite2D node, Vector2 velocity, string choice
 		choice = ("_"+choice);
 	}
 	if(type == ""){
-		type = species;
+		type = PlayerData.Race;
 	}
 		
 	if(velocity.X != 0){

--- a/3380-game/Assets/Sprites/bodies/3380 player_b1.png.import
+++ b/3380-game/Assets/Sprites/bodies/3380 player_b1.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cr1jnakw4drkq"
-path="res://.godot/imported/3380 player_b1.png-365dcb89a9375b4b3dab2806ded30918.ctex"
+path="res://.godot/imported/3380 player_b1.png-4174d14c4413bc3d150726a1e632e215.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Assets/Sprites/3380 player_b1.png"
-dest_files=["res://.godot/imported/3380 player_b1.png-365dcb89a9375b4b3dab2806ded30918.ctex"]
+source_file="res://Assets/Sprites/bodies/3380 player_b1.png"
+dest_files=["res://.godot/imported/3380 player_b1.png-4174d14c4413bc3d150726a1e632e215.ctex"]
 
 [params]
 


### PR DESCRIPTION
This pull request adds and utilizes a `PlayerData` property to `Player` so that any code written can rely on the properties inside PlayerData, which would be created by a character creation screen. As it stands, we do not have such a screen, and so to prevent issues during development, the property is currently initialized with an instance of PlayerData containing default values. There are also some hard-coded values inside the Player class which do not have a direct equivalent in our PlayerData class, so those are unable to be removed.