### PR TITLE
Prevent playing without save file

### DIFF
--- a/3380-game/3380 Game.csproj.old.1
+++ b/3380-game/3380 Game.csproj.old.1
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.4.1">
+<Project Sdk="Godot.NET.Sdk/4.4.0">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/3380-game/Assets/Scripts/MainMenu.cs
+++ b/3380-game/Assets/Scripts/MainMenu.cs
@@ -44,6 +44,10 @@ public partial class MainMenu : CanvasLayer
 	
 	///Creates the functionality of the Play button when pressed
 	public void OnPlayPressed(){
+		// Do not allow playing if the character creator save file has not been created
+		using var file = FileAccess.Open("user://playerSprite0.dat", FileAccess.ModeFlags.Read);
+		if (file is null) return;
+		
 		Visible = false;
 		GetTree().Paused = false;
 		

--- a/3380-game/Assets/Scripts/Saving/Savable.cs.uid
+++ b/3380-game/Assets/Scripts/Saving/Savable.cs.uid
@@ -1,0 +1,1 @@
+uid://bewtjfjn15ikx


### PR DESCRIPTION
This pull request ensures that the option to continue playing is non-functional unless the save file associated with it is on the user's file system, fixing the bug "Cannot Move Player" in our bug tracker.