### PR TITLE
Add experience/leveling system

### DIFF
--- a/3380-game/Assets/Scripts/CharCreate.cs
+++ b/3380-game/Assets/Scripts/CharCreate.cs
@@ -2,6 +2,7 @@ using Godot;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Game.Assets.Scripts;
 
 public partial class PlayerData : GodotObject
 {
@@ -16,7 +17,7 @@ public partial class PlayerData : GodotObject
 	public Color EyeColor { get; set; }
 	public Color HairColor { get; set; }
 	public Color FacialMarkings { get; set; }
-
+	public Experience Experience { get; private set; }
 
 
 	public int Strength { get; set; }
@@ -40,7 +41,7 @@ public partial class PlayerData : GodotObject
 		EyeColor = eyeColor;
 		HairColor = hairColor;
 		FacialMarkings = facialMarkings;
-
+		Experience = new Experience();
 
 		Random rand = new Random();
 		Strength = rand.Next(1, 21);

--- a/3380-game/Assets/Scripts/Experience.cs
+++ b/3380-game/Assets/Scripts/Experience.cs
@@ -8,11 +8,15 @@ public sealed class Experience(uint points)
     {
     }
     
+    /// <summary>
+    /// Adds the specified number of points to the total stored points
+    /// </summary>
+    /// <param name="points"></param>
     public void AddPoints(uint points) => Points += points;
     
     /// <summary>
     /// Converts the total number of points to a level using the inverse of our level to points formula
-    /// This inverse formula is not exact given the use of ceil and floor functions in the original, but the difference is insignificant
+    /// This inverse formula is not exact given the use of ceil and floor functions in the original formula, but the difference is negligible
     /// </summary>
     /// <returns>The level associated with the number of points in this Experience object</returns>
     public int GetLevel()

--- a/3380-game/Assets/Scripts/Experience.cs
+++ b/3380-game/Assets/Scripts/Experience.cs
@@ -1,0 +1,24 @@
+namespace Game.Assets.Scripts;
+
+public sealed class Experience(uint points)
+{
+    public uint Points { get; private set; } = points;
+
+    public Experience() : this(0)
+    {
+    }
+    
+    public void AddPoints(uint points) => Points += points;
+    
+    /// <summary>
+    /// Converts the total number of points to a level using the inverse of our level to points formula
+    /// This inverse formula is not exact given the use of ceil and floor functions in the original, but the difference is insignificant
+    /// </summary>
+    /// <returns>The level associated with the number of points in this Experience object</returns>
+    public int GetLevel()
+    {
+        var numerator = (-0.25f * double.Sqrt(Points) - 5) * (5 - 0.0005f * double.Sqrt(Points));
+        var denominator = 25 - 0.00000025 * Points;
+        return -(int)(numerator / denominator);
+    }
+}

--- a/3380-game/Assets/Scripts/Experience.cs.uid
+++ b/3380-game/Assets/Scripts/Experience.cs.uid
@@ -1,0 +1,1 @@
+uid://cfdbcov0ljwwo

--- a/3380-game/Assets/Scripts/Player.cs
+++ b/3380-game/Assets/Scripts/Player.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System;
+using Game.Assets.Scripts;
 using Game.Assets.Scripts.Loading;
 using Game.Assets.Scripts.Saving;
 
@@ -31,7 +32,6 @@ public override void _Ready() //called on start
 	Load();
 	LoadSprite();
 	direction = "front";
-	
 	body = GetNode<AnimatedSprite2D>("Body");
 	head = GetNode<AnimatedSprite2D>("Head");
 	eye = GetNode<AnimatedSprite2D>("Eyes");
@@ -50,7 +50,6 @@ public override void _Process(double delta) //called in real time
 	if (Input.IsActionPressed("move_left")){velocity.X -= 1; direction = "side";}
 	if (Input.IsActionPressed("move_down")){velocity.Y += 1; direction = "front";}
 	if (Input.IsActionPressed("move_up")){velocity.Y -= 1; direction = "back";}
-	
 //movement and animation controls
 	AnimationTurn(body, velocity, bodyType, "body");
 	body.SelfModulate = (playerData.SkinColor);
@@ -149,10 +148,11 @@ public void AnimationTurn(AnimatedSprite2D node, Vector2 velocity, string choice
 public void Load()
 	{   //for some reason once i run the bitch enough times it breaks. for no reason. if that happens to you,
 		//just change the file name to something that hasnt been used yet and it should be fine.
-		using var file = FileAccess.Open("user://playerData2.dat", FileAccess.ModeFlags.Read);
+		using var file = FileAccess.Open("user://playerData_v3.dat", FileAccess.ModeFlags.Read);
 		if (file is not null)
 		{	
 			Position = (Vector2)file.GetVar();
+			playerData.Experience.AddPoints(file.Get32());
 		}
 	}
 
@@ -180,8 +180,9 @@ public void LoadSprite(){
 
 	public void Save()
 	{
-		using var file = FileAccess.Open("user://playerData2.dat", FileAccess.ModeFlags.Write);
+		using var file = FileAccess.Open("user://playerData_v3.dat", FileAccess.ModeFlags.Write);
 		file.StoreVar(Position);
+		file.Store32(playerData.Experience.Points);
 	}
 //end of code <- keep right before final bracket
 }


### PR DESCRIPTION
This pull request adds a class called `Experience` that provides a system for adding experience points and calculating a level based on the total experience points. This class is instantiated and attached when the `PlayerData` class is instantiated, and code has been added to our `Player` class to save and load the number of points for the user. Please note, however, that this saving and loading will not currently work due to the bug "Player data not saving" in our issue tracker.