### PR TITLE
Fix "Bug - Player data not saving"

### DIFF
--- a/3380-game/Assets/Scripts/PauseScreen.cs
+++ b/3380-game/Assets/Scripts/PauseScreen.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System;
+using Game.Assets.Scripts.Saving;
 
 public partial class PauseScreen : CanvasLayer
 {
@@ -22,6 +23,19 @@ public partial class PauseScreen : CanvasLayer
 			GetTree().Paused = false;
 			}
 	public void QuitPressed(){
+		foreach (var scene in GetTree().GetRoot().GetChildren())
+		{
+			// Only save nodes in the Main scene, as we do not currently need saving for other nodes
+			if (!scene.Name.Equals("Main")) continue;
+			
+			foreach (var child in scene.GetChildren())
+			{
+				if (child is Savable savable)
+				{
+					savable.Save();
+				}
+			}
+		}
 		GetTree().Quit();
 	}
 	public void InventoryPressed(){

--- a/3380-game/Assets/Scripts/Player.cs
+++ b/3380-game/Assets/Scripts/Player.cs
@@ -4,7 +4,7 @@ using Game.Assets.Scripts;
 using Game.Assets.Scripts.Loading;
 using Game.Assets.Scripts.Saving;
 
-public partial class Player : Area2D
+public partial class Player : Area2D, Loadable, Savable
 {
 	[Export]
 	public int Speed { get; set; } = 200; // How fast the player will move (pixels/sec).
@@ -29,8 +29,8 @@ public partial class Player : Area2D
 public override void _Ready() //called on start
 {
 	screenSize = GetViewportRect().Size;
-	Load();
 	LoadSprite();
+	Load();
 	direction = "front";
 	body = GetNode<AnimatedSprite2D>("Body");
 	head = GetNode<AnimatedSprite2D>("Head");


### PR DESCRIPTION
This pull request adds logic to the pause screen menu to save any children of the Main scene that inherit `Savable` and adds that attribute back to the Player class (though it is unclear why this was ever removed to begin with). This fixes the bug in our issue tracker that corresponds with player data not saving upon exiting.