### PR TITLE
Fix "Bug - Pause menu accessible from Main Menu"

### DIFF
--- a/3380-game/Assets/Scripts/MainMenu.cs
+++ b/3380-game/Assets/Scripts/MainMenu.cs
@@ -18,7 +18,7 @@ public partial class MainMenu : CanvasLayer
 	///set the visibility of the main menu screen to true, as well as call the GetTree.Paused to pause the game when 'esc' is pressed.
 	public override void _Process(double delta){
 
-		if(Input.IsActionJustPressed("ui_cancel")){
+		if(Input.IsActionJustPressed("ui_cancel") && !Visible){
 			TogglePauseScreen();
 			GetTree().Paused = !GetTree().Paused;
 		}

--- a/3380-game/Scenes/Player.tscn
+++ b/3380-game/Scenes/Player.tscn
@@ -1,7 +1,6 @@
 [gd_scene load_steps=108 format=3 uid="uid://m81cq124ltn8"]
 
 [ext_resource type="Script" uid="uid://dkqs8ewlx432x" path="res://Assets/Scripts/Player.cs" id="1_ovr1q"]
-
 [ext_resource type="Texture2D" uid="uid://bhp05vupkwq8h" path="res://Assets/Sprites/Hairs/3380 player_hair_long.png" id="2_em26k"]
 [ext_resource type="Texture2D" uid="uid://cr1jnakw4drkq" path="res://Assets/Sprites/bodies/3380 player_b1.png" id="4_0ap8a"]
 [ext_resource type="Texture2D" uid="uid://c7r1blir0xf6j" path="res://Assets/Sprites/heads/3380 player_h1-4.png" id="5_om6ds"]


### PR DESCRIPTION
This pull request checks the visibility of the Main Menu scene before allowing the pause menu to appear, fixing a bug where the pause menu was able to be accessed from the main menu.