### PR TITLE
Set character name on textbox change

### DIFF
--- a/3380-game/Assets/Scripts/Character_Select.cs
+++ b/3380-game/Assets/Scripts/Character_Select.cs
@@ -67,8 +67,9 @@ public partial class Character_Select : Control
 		playerData.FacialMarkings = color;
 		EmitSignal(SignalName.PDat, playerData);
 	}
-	public void NameSet(){
-		name = "Placeholder";
+	public void NameTextChanged(){
+		var textBox = (TextEdit)GetNode("Name");
+		name = textBox.Text;
 		playerData.Name = name;
 		EmitSignal(SignalName.PDat, playerData);
 	}

--- a/3380-game/Scenes/character_creation.tscn
+++ b/3380-game/Scenes/character_creation.tscn
@@ -161,5 +161,6 @@ offset_bottom = 238.0
 [connection signal="color_changed" from="Control/Eye/EyeColor" to="Control" method="EyeColor"]
 [connection signal="item_selected" from="Control/Pattern" to="Control" method="PatternSelect"]
 [connection signal="color_changed" from="Control/Pattern/PatternColor" to="Control" method="PatternColor"]
+[connection signal="text_changed" from="Control/Name" to="Control" method="NameTextChanged"]
 [connection signal="text_set" from="Control/Name" to="Control" method="NameSet"]
 [connection signal="pressed" from="Control/Confirm" to="Control" method="Continue"]


### PR DESCRIPTION
This pull request modifies the current signal for the name textbox to be when the contents of the textbox change and saves the contents as the player's name, replacing the placeholder name that is currently utilized.