### PR TITLE
Fix "Bug - User can create character without name/class"

### DIFF
--- a/3380-game/Assets/Scripts/Character_Select.cs
+++ b/3380-game/Assets/Scripts/Character_Select.cs
@@ -85,9 +85,9 @@ public partial class Character_Select : Control
 		playerData.FacialMarkings = color;
 		EmitSignal(SignalName.PDat, playerData);
 	}
-	public void NameTextChanged(){
-		var textBox = (TextEdit)GetNode("Name");
-		name = textBox.Text;
+	public void NameTextChanged(String newText)
+	{
+		name = newText;
 		playerData.Name = name;
 		EmitSignal(SignalName.PDat, playerData);
 	}

--- a/3380-game/Assets/Scripts/Character_Select.cs
+++ b/3380-game/Assets/Scripts/Character_Select.cs
@@ -141,6 +141,7 @@ public partial class Character_Select : Control
 	}
 	
 	public void Continue(){
+		if (playerData.Class.Equals("No Input") || playerData.Name.Equals("No Input")) return;
 		EmitSignal(SignalName.PDat, playerData);
 		EmitSignal(SignalName.PStats, stats);
 		Save();

--- a/3380-game/Scenes/character_creation.tscn
+++ b/3380-game/Scenes/character_creation.tscn
@@ -402,7 +402,7 @@ text = "10 (+0)"
 [connection signal="color_changed" from="Control/Eye/EyeColor" to="Control" method="EyeColor"]
 [connection signal="item_selected" from="Control/Pattern" to="Control" method="PatternSelect"]
 [connection signal="color_changed" from="Control/Pattern/PatternColor" to="Control" method="PatternColor"]
-[connection signal="text_submitted" from="Control/Name" to="Control" method="NameSet"]
+[connection signal="text_changed" from="Control/Name" to="Control" method="NameTextChanged"]
 [connection signal="item_selected" from="Control/Class" to="Control" method="ClassSelect"]
 [connection signal="pressed" from="Control/Confirm" to="Control" method="Continue"]
 [connection signal="pressed" from="Control/Stat Randomizer" to="Control" method="Randomizer"]


### PR DESCRIPTION
This pull request adds input validation to the Character Creation screen and migrates the name text change signal handler to account for the change to `LineEdit`, fixing a bug where the user was able to create a character without a name or a class.